### PR TITLE
Remove filtering of 'digitalcardPartner' from partners

### DIFF
--- a/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/main/java/io/mosip/registration/processor/credentialrequestor/stage/CredentialRequestorStage.java
+++ b/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/main/java/io/mosip/registration/processor/credentialrequestor/stage/CredentialRequestorStage.java
@@ -318,7 +318,6 @@ public class CredentialRequestorStage extends MosipVerticleAPIManager {
 
 				if (!isAdult && !isAlien) {
 					filteredPartners.removeIf(p -> "printPartner".equals(p.getId()));
-					filteredPartners.removeIf(p -> "digitalcardPartner".equals(p.getId()));
 				}
 				
 				for (CredentialPartner key : filteredPartners) {


### PR DESCRIPTION
Removed the condition to filter out 'digitalcardPartner' from filteredPartners when the user is not an adult and not an alien.